### PR TITLE
Repairs on the Build System after source refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ if (MSVC)
     set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} /W4")
 endif()
 
+# Deactivate bugged warnings
+if (CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces")
+endif()
+
 # add_subdirectory(tests/)
 add_subdirectory(src/)
 add_subdirectory(tests/ubc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(operationalspace C)
 
 set(CMAKE_C_STANDARD 99)
 
+# Directories
+SET(COMMON_DIR "${CMAKE_SOURCE_DIR}/src/common")
+SET(SERVER_DIR "${CMAKE_SOURCE_DIR}/src/server")
+SET(CLIENT_DIR "${CMAKE_SOURCE_DIR}/src/client")
+SET(UBC_DIR "${CMAKE_SOURCE_DIR}/src/server/ubc")
+
 # Activate warnings
 if (CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,5 @@ if (CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces")
 endif()
 
-# add_subdirectory(tests/)
+add_subdirectory(tests/)
 add_subdirectory(src/)
-add_subdirectory(tests/ubc)

--- a/src/server/ubc/CMakeLists.txt
+++ b/src/server/ubc/CMakeLists.txt
@@ -8,8 +8,13 @@ target_sources(os-server PRIVATE parser.c
 
 # Ubcparser Library
 add_library(ubcparser STATIC EXCLUDE_FROM_ALL
-          parser.c)
+          parser.c
+          tokenreader.c
+          "${COMMON_DIR}/util.c"
+          "${COMMON_DIR}/lexer/lexer.c")
 target_include_directories(ubcparser BEFORE
-          PRIVATE ../../common)
+          PRIVATE "${COMMON_DIR}")
+set_target_properties(ubcparser PROPERTIES
+          ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/libs/ubc")
 
 add_custom_target(ubclibs DEPENDS ubcparser)

--- a/src/server/ubc/CMakeLists.txt
+++ b/src/server/ubc/CMakeLists.txt
@@ -1,3 +1,15 @@
+project(ubc C)
+
+# Sources for server
 target_sources(os-server PRIVATE parser.c
             tokenreader.c
             ubcvm.c)
+
+
+# Ubcparser Library
+add_library(ubcparser STATIC EXCLUDE_FROM_ALL
+          parser.c)
+target_include_directories(ubcparser BEFORE
+          PRIVATE ../../common)
+
+add_custom_target(ubclibs DEPENDS ubcparser)

--- a/src/server/world.c
+++ b/src/server/world.c
@@ -13,7 +13,7 @@ void World_Create(world_t* world, unsigned int width, unsigned int height)
 int World_GetSector(world_t* world, size_t row, size_t col, sector_t** destination)
 {
     size_t index;
-    
+
     if (world == NULL)
         return EINVAL;
     if (row >= world->sectorsY)
@@ -52,8 +52,8 @@ void World_DebugDump(world_t* world, char* filename)
 
     f = fopen(filename, "wb");
 
-    for (int x = 0; x < world->sectorsX * SECTOR_SIZE; x++) {
-        for (int y = 0; y < world->sectorsY * SECTOR_SIZE; y++) {
+    for (unsigned int x = 0; x < world->sectorsX * SECTOR_SIZE; x++) {
+        for (unsigned int y = 0; y < world->sectorsY * SECTOR_SIZE; y++) {
             t = World_GetTile(world, x, y);
             fwrite(&t->glyph, 1, 1, f);
         }

--- a/src/server/world.h
+++ b/src/server/world.h
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <math.h>
 
-#include <world.h>
 #include <sector.h>
 #include <feature.h>
 
@@ -35,7 +34,7 @@ void World_Create(world_t* world, unsigned int width, unsigned int height);
 /// @return int, errorcodes (EINVAL, EDESTADDRREQ)
 int World_GetSector(world_t* world, size_t row, size_t col, sector_t** destination);
 
-/// @brief Get a tile from its absolute address 
+/// @brief Get a tile from its absolute address
 /// @param x The tiles absolute x-position
 /// @param y The tiles absolute y-position
 /// @return Pointer to the requested tile struct

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(worldgen EXCLUDE_FROM_ALL worldgen.test.c
 					../src/server/worldgen.c
 					../src/common/rand/xoshiro256.c
 					../src/common/rand/opensimplex.c)
+target_include_directories(worldgen BEFORE PRIVATE "${SERVER_DIR}" "${COMMON_DIR}")
 set_target_properties(worldgen PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test")
 target_link_libraries(worldgen m)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,44 +2,44 @@ project(termtest C)
 
 add_executable(os-termtest
 			ansitest.c
-			../src/ui/window.c)
+			../src/client/ui/window.c)
 set_target_properties(os-termtest PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
 
 add_executable(coordinates EXCLUDE_FROM_ALL coordinate.test.c
-					../src/logic/coordinate/coordinate.c
-					../src/logic/arraylist/arraylist.c)
+					../src/common/coordinate/coordinate.c
+					../src/common/arraylist/arraylist.c)
 set_target_properties(coordinates PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test")
 
 
 add_executable(lexer EXCLUDE_FROM_ALL lexertest.c
-					../src/logic/lexer/lexer.c)
+					../src/common/lexer/lexer.c)
 set_target_properties(lexer PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test")
 
 add_executable(memorypool EXCLUDE_FROM_ALL memorypool.test.c
-					../src/logic/memorypool/memorypool.c
-					../src/logic/memorypool/memoryarena.c)
+					../src/common/memorypool/memorypool.c
+					../src/common/memorypool/memoryarena.c)
 set_target_properties(memorypool PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test")
 
 add_executable(opensimplex EXCLUDE_FROM_ALL opensimplex.test.c
-					../src/logic/rand/opensimplex.c)
+					../src/common/rand/opensimplex.c)
 set_target_properties(opensimplex PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test")
 target_link_libraries(opensimplex m)
 
-add_executable(thread EXCLUDE_FROM_ALL thread.test.c ../src/logic/threading/threading.c)
+add_executable(thread EXCLUDE_FROM_ALL thread.test.c ../src/common/threading/threading.c)
 set_target_properties(thread PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test")
 
 add_executable(worldgen EXCLUDE_FROM_ALL worldgen.test.c
-					../src/logic/arraylist/arraylist.c
-					../src/logic/coordinate/coordinate.c
-					../src/game/world.c
-					../src/game/worldgen.c
-					../src/logic/rand/xoshiro256.c
-					../src/logic/rand/opensimplex.c)
+					../src/common/arraylist/arraylist.c
+					../src/common/coordinate/coordinate.c
+					../src/server/world.c
+					../src/server/worldgen.c
+					../src/common/rand/xoshiro256.c
+					../src/common/rand/opensimplex.c)
 set_target_properties(worldgen PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test")
 target_link_libraries(worldgen m)
 
 add_executable(xoshiro EXCLUDE_FROM_ALL xoshiro.test.c
-					../src/logic/rand/xoshiro256.c)
+					../src/common/rand/xoshiro256.c)
 set_target_properties(xoshiro PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test")
 target_link_libraries(xoshiro m)
 

--- a/tests/ansitest.c
+++ b/tests/ansitest.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include "../src/ui/window.h"
+#include "../src/client/ui/window.h"
 
 void RegisTest()
 {
@@ -30,7 +30,7 @@ int main()
 {
     window_t win;
 	char choice;
-    
+
     Window_CreateWindow(80, 24, &win);
 	Window_SetCursorVisible(false);
     Window_ClearScreen();
@@ -40,7 +40,7 @@ int main()
 	printf("OperationalSpace Terminal Capability Test\n\n");
 	Window_ResetFormatting();
 
-	
+
 	// Text Formatting Test
 	printf("Test Normal\n");
 	Window_SetBold(true);
@@ -115,7 +115,7 @@ int main()
 		Window_SetColor(7, 0);
 		Window_SetBlinking(false);
 		printf(" for ReGIS test.");
-		
+
 		choice = getchar();
 		switch (choice) {
 			case 's':

--- a/tests/coordinate.test.c
+++ b/tests/coordinate.test.c
@@ -1,5 +1,5 @@
-#include "../src/logic/coordinate/coordinate.h"
-#include "../src/logic/arraylist/arraylist.h"
+#include "../src/common/coordinate/coordinate.h"
+#include "../src/common/arraylist/arraylist.h"
 
 #include <stdio.h>
 

--- a/tests/lexertest.c
+++ b/tests/lexertest.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include "../src/logic/lexer/lexer.h"
+#include "../src/common/lexer/lexer.h"
 
 int main(int argc, char** argv)
 {

--- a/tests/memorypool.test.c
+++ b/tests/memorypool.test.c
@@ -1,5 +1,5 @@
-#include "../src/logic/memorypool/memorypool.h"
-#include "../src/logic/memorypool/memoryarena.h"
+#include "../src/common/memorypool/memorypool.h"
+#include "../src/common/memorypool/memoryarena.h"
 
 #include <assert.h>
 #include <string.h>
@@ -60,7 +60,7 @@ void check_both(void)
     assert(!MemoryPool_AllocateArray(&pool, 274, (void**) &array));
     assert(MemoryPool_Allocate(&pool, (void**) &_) == ENOMEM);
     assert(MemoryPool_AllocateArray(&pool, 1, (void**) &_) == ENOMEM);
-    
+
     for (int i = 0; i < 50; i++) {
         assert(!MemoryPool_Free(&pool, first[i]));
         assert(!MemoryPool_Free(&pool, second[i]));
@@ -87,7 +87,7 @@ void check_both(void)
         assert(MemoryPool_Free(&pool, (void**) second[i]) == EXIT_SUCCESS);
         assert(MemoryPool_Free(&pool, (void**) first[i]) == EXIT_SUCCESS);
     }
-    
+
     MemoryPool_Destroy(&pool);
 }
 

--- a/tests/opensimplex.test.c
+++ b/tests/opensimplex.test.c
@@ -1,4 +1,4 @@
-#include "../src/logic/rand/opensimplex.h"
+#include "../src/common/rand/opensimplex.h"
 #include <stdio.h>
 #include <float.h>
 

--- a/tests/thread.test.c
+++ b/tests/thread.test.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include "../src/logic/threading/threading.h"
+#include "../src/common/threading/threading.h"
 
 #ifdef _WIN32
 void foo(void* a)

--- a/tests/ubc/CMakeLists.txt
+++ b/tests/ubc/CMakeLists.txt
@@ -1,60 +1,23 @@
 project(ubctests C)
 
-add_executable(eof EXCLUDE_FROM_ALL eof.test.c
-                ../../src/server/ubc/parser.c
-                ../../src/common/lexer/lexer.c
-                ../../src/server/ubc/tokenreader.c
-                ../../src/common/util.c)
-set_target_properties(eof PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
-
-add_executable(include EXCLUDE_FROM_ALL include.test.c
-                ../../src/server/ubc/parser.c
-                ../../src/common/lexer/lexer.c
-                ../../src/server/ubc/tokenreader.c
-                ../../src/common/util.c)
-set_target_properties(include PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
-
-add_executable(nestedtypes EXCLUDE_FROM_ALL nestedtypes.test.c
-                ../../src/server/ubc/parser.c
-                ../../src/common/lexer/lexer.c
-                ../../src/server/ubc/tokenreader.c
-                ../../src/common/util.c)
-set_target_properties(nestedtypes PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
-
-add_executable(unknownvar EXCLUDE_FROM_ALL unknownvar.test.c
-                ../../src/server/ubc/parser.c
-                ../../src/common/lexer/lexer.c
-                ../../src/server/ubc/tokenreader.c
-                ../../src/common/util.c)
-set_target_properties(unknownvar PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
-
-add_executable(addition EXCLUDE_FROM_ALL addition.test.c
-                ../../src/server/ubc/parser.c
-                ../../src/common/lexer/lexer.c
-                ../../src/server/ubc/tokenreader.c
-                ../../src/common/util.c)
-set_target_properties(addition PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
-
-add_executable(literalmath EXCLUDE_FROM_ALL literalmath.test.c
-                ../../src/server/ubc/parser.c
-                ../../src/common/lexer/lexer.c
-                ../../src/server/ubc/tokenreader.c
-                ../../src/common/util.c)
-set_target_properties(literalmath PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
-
-add_executable(customtype EXCLUDE_FROM_ALL customtype.test.c
-                ../../src/server/ubc/parser.c
-                ../../src/common/lexer/lexer.c
-                ../../src/server/ubc/tokenreader.c
-                ../../src/common/util.c)
-set_target_properties(customtype PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
-
-add_executable(logic-and EXCLUDE_FROM_ALL logic-and.test.c
-                ../../src/server/ubc/parser.c
-                ../../src/common/lexer/lexer.c
-                ../../src/server/ubc/tokenreader.c
-                ../../src/common/util.c)
-set_target_properties(logic-and PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
+add_custom_target(ubctests)
 
 
-add_custom_target(ubctests DEPENDS eof include nestedtypes unknownvar addition literalmath customtype logic-and)
+function(ubctestexecutable name)
+  set("target_name" "ubctests-${name}")
+  add_executable("${target_name}" EXCLUDE_FROM_ALL "${name}.test.c")
+  target_include_directories("${target_name}" BEFORE PRIVATE "${UBC_DIR}" "${COMMON_DIR}")
+  target_link_libraries("${target_name}" ubcparser)
+  set_target_properties("${target_name}" PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/test/ubc")
+  set_target_properties("${target_name}" PROPERTIES RUNTIME_OUTPUT_NAME "${name}")
+  add_dependencies(ubctests "${target_name}")
+  unset("target_name")
+endfunction()
+
+file(GLOB ubctestfiles "*.test.c")
+
+foreach(file ${ubctestfiles})
+  string(REPLACE ".test.c" ""  "basename" "${file}")
+  string(REGEX REPLACE "/.*/" "" "executable_name" "${basename}")
+  ubctestexecutable("${executable_name}")
+endforeach()

--- a/tests/ubc/addition.test.c
+++ b/tests/ubc/addition.test.c
@@ -1,4 +1,4 @@
-#include "../../src/logic/ubc/parser.h"
+#include <parser.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/ubc/customtype.test.c
+++ b/tests/ubc/customtype.test.c
@@ -1,4 +1,4 @@
-#include "../../src/logic/ubc/parser.h"
+#include <parser.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/ubc/eof.test.c
+++ b/tests/ubc/eof.test.c
@@ -1,4 +1,4 @@
-#include "../../src/logic/ubc/parser.h"
+#include <parser.h>
 
 #include <assert.h>
 

--- a/tests/ubc/include.test.c
+++ b/tests/ubc/include.test.c
@@ -1,4 +1,4 @@
-#include "../../src/logic/ubc/parser.h"
+#include <parser.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/ubc/literalmath.test.c
+++ b/tests/ubc/literalmath.test.c
@@ -1,4 +1,4 @@
-#include "../../src/logic/ubc/parser.h"
+#include <parser.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/ubc/logic-and.test.c
+++ b/tests/ubc/logic-and.test.c
@@ -1,4 +1,4 @@
-#include "../../src/logic/ubc/parser.h"
+#include <parser.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/ubc/nestedtypes.test.c
+++ b/tests/ubc/nestedtypes.test.c
@@ -1,4 +1,4 @@
-#include "../../src/logic/ubc/parser.h"
+#include <parser.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/ubc/unknownvar.test.c
+++ b/tests/ubc/unknownvar.test.c
@@ -1,4 +1,4 @@
-#include "../../src/logic/ubc/parser.h"
+#include <parser.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/worldgen.test.c
+++ b/tests/worldgen.test.c
@@ -1,7 +1,7 @@
-#include "../src/game/world.h"
-#include "../src/logic/arraylist/arraylist.h"
-#include "../src/logic/coordinate/coordinate.h"
-#include "../src/game/worldgen.h"
+#include "world.h"
+#include "worldgen.h"
+#include "arraylist/arraylist.h"
+#include "coordinate/coordinate.h"
 
 #include <stdio.h>
 
@@ -26,14 +26,15 @@ int main()
 	feature_t features[2];
 	features[0].provider = feature_provider;
 	memset(features[0].minimum_noise_levels, 0x00, NOISE_COUNT * sizeof(uint16_t));
-	memset(features[0].maximum_noise_levels, 0xFF, NOISE_COUNT * sizeof(uint16_t)); 
+	memset(features[0].maximum_noise_levels, 0xFF, NOISE_COUNT * sizeof(uint16_t));
 	features[1].provider             = NULL;
 	int world_code = WorldGen_GenerateWorld(&world, features, seed);
 
 	printf("generate_world exited with %i\n",world_code);
 
-	for (size_t row = 0; row < world.sector_rows * SECTOR_SIZE; row++) {
-		for (size_t col = 0; col < world.sector_cols * SECTOR_SIZE; col++) {
+
+	for (size_t row = 0; row < world.sectorsY * SECTOR_SIZE; row++) {
+		for (size_t col = 0; col < world.sectorsX * SECTOR_SIZE; col++) {
 			tile_t* tile = World_GetTile(&world, col, row);
 			if (tile->object) free(tile->object);
 		}

--- a/tests/xoshiro.test.c
+++ b/tests/xoshiro.test.c
@@ -1,4 +1,4 @@
-#include "../src/logic/rand/xoshiro256.h"
+#include "../src/common/rand/xoshiro256.h"
 
 #include <stdio.h>
 


### PR DESCRIPTION
Everything points to the correct folders again and builds and compiles (some with warning though).
Tested on Fedora with
- cmake 3.27.7
- cc (GCC) 13.2.1

I also changed the ubc-test build system to automatically build all .test.c files in the /tests/ubc directory